### PR TITLE
Remove separate GCR login step from stack push timage workflow.

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -42,14 +42,6 @@ jobs:
         # paketo-buildpacks/some-name-stack --> some-name
         echo "::set-output name=name::$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')"
 
-    - name: Login to GCR
-      if: ${{ startsWith(steps.registry-repo.outputs.name, 'bionic-') }}
-      uses: docker/login-action@v2
-      with:
-        registry: gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
-
     - name: Push to DockerHub
       id: push
       env:


### PR DESCRIPTION
We explicitly run `skopeo login` which does not rely on docker login.

This PR will be made to https://github.com/paketo-buildpacks/github-config once we have validated that it pushes images to GCR successfully.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
